### PR TITLE
Don't show chinese version by default

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ localizer, etc.
 
 <ul>
 {% for post in site.posts %}
- {% unless post.title contains "_cn" %}
+ {% unless post.url contains "_cn" %}
    <li><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
  {% endunless %}
 {% endfor %}


### PR DESCRIPTION
In the previous website version, we didn't display the chinese version on the post list so I hide it again like it was before. The article remains accessible through the english version.